### PR TITLE
base release name off of sha instead of ref

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,8 +40,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        tag_name: ${{ github.shas }}
+        release_name: Release ${{ github.sha }}
         draft: false
         prerelease: false
 


### PR DESCRIPTION
The release name shouldn't be based off of the ref, because you can't have 2 releases named the same.

Hopefully this fixes the problem I've been having with Actions