### PR TITLE
chore: update go.mod bump go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/iggy/gocate
 
-go 1.18
+go 1.22
 
 require (
 	github.com/minio/highwayhash v1.0.3


### PR DESCRIPTION
Update to a newer go version